### PR TITLE
Clippy warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,8 @@ jobs:
         sudo apt-get install -y zlib1g-dev libelf-dev
     - name: Test
       run: cargo test
+    - name: clippy
+      run: cargo clippy --all --tests --all-features --no-deps
     - name: Build
       run: cargo build --release
     - name: Create Release and Upload Artficat

--- a/src/app.rs
+++ b/src/app.rs
@@ -151,10 +151,7 @@ impl App {
         let items = self.items.lock().unwrap();
         let state = self.state.lock().unwrap();
 
-        match state.selected() {
-            Some(i) => Some(items[i].clone()),
-            None => None,
-        }
+        state.selected().map(|i| items[i].clone())
     }
     pub fn next_program(&mut self) {
         let items = self.items.lock().unwrap();
@@ -320,11 +317,11 @@ mod tests {
         let mut app = App::new();
 
         // Initially, show_graphs is false
-        assert_eq!(app.show_graphs, false);
+        assert!(!app.show_graphs);
 
         // After calling toggle_graphs, show_graphs should be true
         app.toggle_graphs();
-        assert_eq!(app.show_graphs, true);
+        assert!(app.show_graphs);
 
         // Set max_cpu, max_eps, and max_runtime to non-zero values
         app.max_cpu = 10.0;
@@ -338,7 +335,7 @@ mod tests {
 
         // After calling toggle_graphs, show_graphs should be false again
         app.toggle_graphs();
-        assert_eq!(app.show_graphs, false);
+        assert!(!app.show_graphs);
 
         // max_cpu, max_eps, and max_runtime should be reset to 0
         assert_eq!(app.max_cpu, 0.0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,7 @@ fn main() -> Result<()> {
     terminal.show_cursor()?;
     terminal.clear()?;
 
+    #[allow(clippy::question_mark)]
     if res.is_err() {
         return res;
     }
@@ -139,9 +140,8 @@ fn run_draw_loop<B: Backend>(terminal: &mut Terminal<B>, mut app: App) -> Result
                     }
                     _ => {}
                 }
-                match (key.modifiers, key.code) {
-                    (KeyModifiers::CONTROL, KeyCode::Char('c')) => return Ok(()),
-                    _ => {}
+                if let (KeyModifiers::CONTROL, KeyCode::Char('c')) = (key.modifiers, key.code) {
+                    return Ok(())
                 }
             }
         }
@@ -210,7 +210,7 @@ fn render_graphs(f: &mut Frame, app: &mut App, area: Rect) {
         total_runtime += val.average_runtime_ns;
     }
 
-    let max_cpu = moving_max_cpu as f64;
+    let max_cpu = moving_max_cpu;
     let max_eps = moving_max_eps as f64;
     let max_runtime = moving_max_runtime as f64;
     let avg_cpu = total_cpu / data_buf.len() as f64;
@@ -417,10 +417,7 @@ fn render_footer(f: &mut Frame, app: &mut App, area: Rect) {
 }
 
 fn running_as_root() -> bool {
-    match nix::unistd::getuid().as_raw() {
-        0 => true,
-        _ => false,
-    }
+    matches!(nix::unistd::getuid().as_raw(), 0)
 }
 
 fn format_percent(num: f64) -> String {


### PR DESCRIPTION
This changes addresses some clippy warnings and adds clippy to the CI 

```
warning: manual implementation of `Option::map`
   --> src/app.rs:154:9
    |
154 | /         match state.selected() {
155 | |             Some(i) => Some(items[i].clone()),
156 | |             None => None,
157 | |         }
    | |_________^ help: try: `state.selected().map(|i| items[i].clone())`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_map
    = note: `#[warn(clippy::manual_map)]` on by default

warning: this block may be rewritten with the `?` operator
   --> src/main.rs:106:5
    |
106 | /     if res.is_err() {
107 | |         return res;
108 | |     }
    | |_____^ help: replace it with: `res.as_ref()?;`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#question_mark
    = note: `#[warn(clippy::question_mark)]` on by default

warning: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> src/main.rs:142:17
    |
142 | /                 match (key.modifiers, key.code) {
143 | |                     (KeyModifiers::CONTROL, KeyCode::Char('c')) => return Ok(()),
144 | |                     _ => {}
145 | |                 }
    | |_________________^ help: try: `if let (KeyModifiers::CONTROL, KeyCode::Char('c')) = (key.modifiers, key.code) { return Ok(()) }`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_match
    = note: `#[warn(clippy::single_match)]` on by default

warning: casting to the same type is unnecessary (`f64` -> `f64`)
   --> src/main.rs:213:19
    |
213 |     let max_cpu = moving_max_cpu as f64;
    |                   ^^^^^^^^^^^^^^^^^^^^^ help: try: `moving_max_cpu`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
    = note: `#[warn(clippy::unnecessary_cast)]` on by default

warning: match expression looks like `matches!` macro
   --> src/main.rs:420:5
    |
420 | /     match nix::unistd::getuid().as_raw() {
421 | |         0 => true,
422 | |         _ => false,
423 | |     }
    | |_____^ help: try: `matches!(nix::unistd::getuid().as_raw(), 0)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro
    = note: `#[warn(clippy::match_like_matches_macro)]` on by default

warning: `bpftop` (bin "bpftop") generated 5 warnings (run `cargo clippy --fix --bin "bpftop"` to apply 3 suggestions)
```